### PR TITLE
Clearly identify result link element(s) on the search page. Fix #4

### DIFF
--- a/pages/result.py
+++ b/pages/result.py
@@ -4,7 +4,7 @@ from selenium.webdriver.common.by import By
 class DuckDuckGoResultPage:
 
     SEARCH_INPUT_FIELD_LOCATOR = (By.ID, 'search_form_input')
-    RESULT_LINK_LOCATOR = (By.CSS_SELECTOR, 'a[data-testid="result-title-a"')
+    RESULT_LINK_LOCATOR = (By.CSS_SELECTOR, 'div.results a[data-testid="result-title-a"')
     MORE_RESULTS_BUTTON_LOCATOR = (By.CSS_SELECTOR, 'a.result--more__btn')
     AD_LINK_LOCATOR = (By.CSS_SELECTOR, 'div.results--ads a[data-testid="result-title-a"')
     NO_RESULTS_LOCATOR = (By.CSS_SELECTOR, 'div.no-results p.no-results__title')


### PR DESCRIPTION
Fixed the locator for search result links on the search result page.

This correction allows to clearly identify search result links and distinguish them from other elements on the page that have same attribute. In this case result links and ad links share the `a[data-testid="result-title-a"` attribute.
https://github.com/lemmetry/selenium-experiment/blob/7934536aa67ab10f6fd00108bbd20d0ce05d0679/pages/result.py#L7
https://github.com/lemmetry/selenium-experiment/blob/7934536aa67ab10f6fd00108bbd20d0ce05d0679/pages/result.py#L9

I've added an additional parameter to `CSS_SELECTOR` for  RESULT_LINK_LOCATOR` to achieve this goal.

https://github.com/lemmetry/selenium-experiment/blob/6aaaeb558cb78dd1958927d72e60b3a8b590dc20/pages/result.py#L7